### PR TITLE
add looker user creation support during enable lease

### DIFF
--- a/ingress_driver/looker.go
+++ b/ingress_driver/looker.go
@@ -162,8 +162,20 @@ func (k *LookerIngressDriver) createUser(email string) (*pkg.LookerCreateUserRes
 
 	if err != nil {
 		log.Errorf("failed to create looker account for email %s : %s", email, err.Error())
-	} else {
-		log.Infof("created looker account for email %s", email)
+		return nil, err
+	}
+
+	log.Infof("created looker account for email:%s id:%s", email, resp.Id)
+	log.Infof("creating looker user credentials email for email:%s", email)
+
+	_, createUserCredEmailErr := client.CreateUserCredentialsEmail(resp.Id, pkg.LookerCreateCredentialsEmailRequest{
+		Email: email,
+		Type:  "email",
+	})
+
+	if createUserCredEmailErr != nil {
+		log.Errorf("failed to create looker user credentials email for email %s : %s", email, createUserCredEmailErr.Error())
+		return nil, createUserCredEmailErr
 	}
 
 	return resp, err

--- a/pkg/looker.go
+++ b/pkg/looker.go
@@ -28,7 +28,16 @@ type LookerCreateUserRequest struct {
 }
 
 type LookerCreateUserResponse struct {
+	Id         int  `json:"id"`
 	IsDisabled bool `json:"is_disabled"`
+}
+
+type LookerCreateCredentialsEmailRequest struct {
+	Email string `json:"email"`
+	Type  string `json:"type"`
+}
+
+type LookerCreateCredentialsEmailResponse struct {
 }
 
 type LookerPatchUserRequest struct {
@@ -66,6 +75,24 @@ func (c *LookerClient) CreateUser(req LookerCreateUserRequest) (*LookerCreateUse
 	method := http.MethodPost
 
 	resp := LookerCreateUserResponse{}
+
+	httpResponse, httpErr := c.executeRequest(path, method, req)
+
+	if httpErr != nil {
+		return nil, httpErr
+	}
+
+	if decodeErr := json.NewDecoder(httpResponse.Body).Decode(&resp); decodeErr != nil {
+		return nil, decodeErr
+	}
+	return &resp, nil
+}
+
+func (c *LookerClient) CreateUserCredentialsEmail(userId int, req LookerCreateCredentialsEmailRequest) (*LookerCreateCredentialsEmailResponse, error) {
+	path := fmt.Sprintf("api/3.1/users/%d/credentials_email", userId)
+	method := http.MethodPost
+
+	resp := LookerCreateCredentialsEmailResponse{}
 
 	httpResponse, httpErr := c.executeRequest(path, method, req)
 

--- a/pkg/looker.go
+++ b/pkg/looker.go
@@ -21,6 +21,16 @@ type LookerClient struct {
 	clientSecret        string
 }
 
+type LookerCreateUserRequest struct {
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Email     string `json:"email"`
+}
+
+type LookerCreateUserResponse struct {
+	IsDisabled bool `json:"is_disabled"`
+}
+
 type LookerPatchUserRequest struct {
 	IsDisabled bool `json:"is_disabled"`
 }
@@ -49,6 +59,24 @@ func GetLookerClient() *LookerClient {
 		}
 	}
 	return client
+}
+
+func (c *LookerClient) CreateUser(req LookerCreateUserRequest) (*LookerCreateUserResponse, error) {
+	path := "api/3.1/users"
+	method := http.MethodPost
+
+	resp := LookerCreateUserResponse{}
+
+	httpResponse, httpErr := c.executeRequest(path, method, req)
+
+	if httpErr != nil {
+		return nil, httpErr
+	}
+
+	if decodeErr := json.NewDecoder(httpResponse.Body).Decode(&resp); decodeErr != nil {
+		return nil, decodeErr
+	}
+	return &resp, nil
 }
 
 func (c *LookerClient) PatchUser(userId int, req LookerPatchUserRequest) (*LookerPatchUserResponse, error) {


### PR DESCRIPTION
Expected req response from looker:

Request1
POST : /users
~~~json
{
    "first_name": "firstname",
    "last_name": "lastname",
    "email": "firstname.lastname@razorpay.com"
}
~~~


Response1
~~~json
{
 "id": 123,
 "is_disabled": false
}
~~~

Request2
POST: /users/:id/credentials_email
~~~json
{
    "email": "firstname.lastname@razorpay.com",
    "type": "email"
}
~~~

Response2
~~~json

~~~
