### PR TITLE
Change parameter to allow only razorpay domains.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -27,7 +27,7 @@ class UserController extends Controller
 
         if (! $code) {
             $url = $google_service->getAuthorizationUri([
-                'hosted_domain' =>  config('concierge.google_domain')
+                'hd' =>  config('concierge.google_domain')
             ]);
 
             return redirect((string) $url);


### PR DESCRIPTION
Currently while logging into concierge we get the option to login using multiple non-org accounts. Changing this `hosted_domain` to `hd` fixes it.

https://developers.google.com/identity/protocols/oauth2/openid-connect#hd-param

https://razorpay.slack.com/archives/C0ZJSSQSV/p1606403241305700