### PR TITLE
Upgrade Go to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM c.rzp.io/razorpay/rzp-docker-image-inventory-multi-arch:rzp-golden-image-base-golang-1.25-alpine3.22 as concierge
+FROM golang:1.25-alpine3.22 as concierge
 RUN apk add git
 WORKDIR /concierge
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN go build -o concierge main.go 
 
 
-FROM alpine:3.16
+FROM alpine:3.22
 
 ENV GOSU_VERSION="1.10"
 ENV ARCH="amd64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.0-alpine3.16 as concierge
+FROM c.rzp.io/razorpay/rzp-docker-image-inventory-multi-arch:rzp-golden-image-base-golang-1.25-alpine3.22 as concierge
 RUN apk add git
 WORKDIR /concierge
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module concierge
 
-go 1.19
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go v1.44.183

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=


### PR DESCRIPTION
## Org N-1 Go Migration: 1.16 → 1.25

This PR upgrades the Go toolchain to 1.25 as part of Razorpay's org-wide effort to keep services on the N-1 Go release for security patches, performance improvements, and toolchain support.

## Changes

- **go directive**: bumped from `1.19` to `1.25` in `go.mod`
- **go mod tidy**: updated `go.sum` accordingly
- **Dockerfile**: replaced public `golang:1.19.0-alpine3.16` base image with internal golden image `c.rzp.io/razorpay/rzp-docker-image-inventory-multi-arch:rzp-golden-image-base-golang-1.25-alpine3.22`
- **CI workflows**: none present (`.github/workflows/` absent) — no pins to update

## Verification

- `go mod tidy` completed successfully
- `go build ./...` passes locally
- No tests found in repository (`go test ./...` reports no tests)
- No vendor directory present

## Notes

- Module name `concierge` is non-canonical but left unchanged (out of scope)
- No pre-existing build or codegen breakage detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)